### PR TITLE
Upgrade run-time to 3.6

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ frameworkVersion: ">=1.2.0 <2.0.0"
 
 provider:
   name: aws
-  runtime: python2.7
+  runtime: python3.6
 
 functions:
   cron:


### PR DESCRIPTION
Upgrades run time from 2.7 => 3.6, because why start with unnecessary tech debt.